### PR TITLE
Request

### DIFF
--- a/web/components/commands/documentation/AddConfluence.tsx
+++ b/web/components/commands/documentation/AddConfluence.tsx
@@ -1,13 +1,12 @@
 import { SearchIcon } from '@heroicons/react/outline'
 import { CheckCircleIcon } from '@heroicons/react/solid'
-import axios from 'axios'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
-import { Org, useProfile, User } from '../../../context/ProfileContext'
+import { useProfile } from '../../../context/ProfileContext'
 import { API_ENDPOINT } from '../../../helpers/api'
 import { classNames } from '../../../helpers/functions'
 import { ConfluencePageIcon } from '../../../helpers/Icons'
-import { getSubdomain } from '../../../helpers/user'
+import { request } from '../../../helpers/request'
 import timeAgo from '../../../services/timeago'
 
 type ConfluencePage = {
@@ -41,17 +40,7 @@ export default function AddConfluence({ onCancel, setIsAddDocumentationOpen, set
     if (user == null || org == null) {
       return;
     }
-    axios
-      .post(
-        `${API_ENDPOINT}/routes/integrations/confluence/sync`,
-        null,
-        {
-          params: {
-            userId: user.userId,
-            subdomain: getSubdomain(window.location.host),
-          },
-        }
-      )
+    request('POST', 'routes/integrations/confluence/sync')
       .then(({ data: { results } }) => {
         console.log(results);
         setPages(results);
@@ -83,17 +72,10 @@ export default function AddConfluence({ onCancel, setIsAddDocumentationOpen, set
 
   const onSubmit = async () => {
     setIsAddDocLoading(true)
-    axios
-      .post(
-        `${API_ENDPOINT}/routes/docs/confluence`,
-        {
-          pages: selectedPages,
-        },
-        {
-          params: {
-            userId: user.userId,
-            subdomain: getSubdomain(window.location.host),
-          },
+    request('POST', 'routes/docs/confluence', {
+          data: {
+            pages: selectedPages,
+          }
         }
       )
       .then(() => {

--- a/web/components/commands/documentation/AddGoogleDocs.tsx
+++ b/web/components/commands/documentation/AddGoogleDocs.tsx
@@ -1,12 +1,11 @@
 import { SearchIcon } from '@heroicons/react/outline'
 import { CheckCircleIcon } from '@heroicons/react/solid'
-import axios from 'axios'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import { useProfile } from '../../../context/ProfileContext'
 import { API_ENDPOINT } from '../../../helpers/api'
 import { classNames } from '../../../helpers/functions'
-import { getSubdomain } from '../../../helpers/user'
+import { request } from '../../../helpers/request'
 import timeAgo from '../../../services/timeago'
 
 type GoogleDoc = {
@@ -35,17 +34,7 @@ export default function AddGoogleDocs({ onCancel, setIsAddDocumentationOpen, set
     if (user == null || org == null) {
       return;
     }
-    axios
-      .post(
-        `${API_ENDPOINT}/routes/integrations/google/sync`,
-        null,
-        {
-          params: {
-            userId: user.userId,
-            subdomain: getSubdomain(window.location.host),
-          },
-        }
-      )
+    request('POST', 'routes/integrations/google/sync')
       .then(({ data: { results } }) => {
         setDocs(results);
         setSelectedDocs(results);
@@ -76,17 +65,11 @@ export default function AddGoogleDocs({ onCancel, setIsAddDocumentationOpen, set
 
   const onSubmit = async () => {
     setIsAddDocLoading(true)
-    axios
-      .post(
-        `${API_ENDPOINT}/routes/docs/googledocs`,
+    request('POST', 'routes/docs/googledocs',
         {
-          docs: selectedDocs,
-        },
-        {
-          params: {
-            userId: user.userId,
-            subdomain: getSubdomain(window.location.host),
-          },
+          data: {
+            docs: selectedDocs,
+          }
         }
       )
       .then(() => {

--- a/web/components/commands/documentation/AddNotion.tsx
+++ b/web/components/commands/documentation/AddNotion.tsx
@@ -1,12 +1,11 @@
 import { SearchIcon } from '@heroicons/react/outline'
 import { CheckCircleIcon } from '@heroicons/react/solid'
-import axios from 'axios'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import { useProfile } from '../../../context/ProfileContext'
 import { API_ENDPOINT } from '../../../helpers/api'
 import { classNames } from '../../../helpers/functions'
-import { getSubdomain } from '../../../helpers/user'
+import { request } from '../../../helpers/request'
 import timeAgo from '../../../services/timeago'
 
 type Icon = {
@@ -44,17 +43,7 @@ export default function AddNotion({ onCancel, setIsAddDocumentationOpen, setIsAd
     if (user == null || org == null) {
       return;
     }
-    axios
-      .post(
-        `${API_ENDPOINT}/routes/integrations/notion/sync`,
-        {},
-        {
-          params: {
-            userId: user.userId,
-            subdomain: getSubdomain(window.location.host),
-          },
-        }
-      )
+    request('POST', 'routes/integrations/notion/sync')
       .then(({ data: { results } }) => {
         const pages = results.map((page: Page) => {
           return { ...page, lastEditedAgo: timeAgo.format(Date.parse(page.lastEditedTime)) }
@@ -88,19 +77,12 @@ export default function AddNotion({ onCancel, setIsAddDocumentationOpen, setIsAd
 
   const onSubmit = async () => {
     setIsAddDocLoading(true)
-    axios
-      .post(
-        `${API_ENDPOINT}/routes/docs/notion`,
-        {
+    request('POST', 'routes/docs/notion',
+      {
+        data: {
           pages: selectedPages,
         },
-        {
-          params: {
-            userId: user.userId,
-            subdomain: getSubdomain(window.location.host),
-          },
-        }
-      )
+      })
       .then(() => {
         setIsAddDocLoading(false)
       })

--- a/web/components/commands/documentation/AddWebpage.tsx
+++ b/web/components/commands/documentation/AddWebpage.tsx
@@ -1,9 +1,8 @@
-import axios from "axios"
 import Link from "next/link"
 import { useEffect, useState } from "react"
 import { useProfile } from "../../../context/ProfileContext"
-import { API_ENDPOINT } from "../../../helpers/api"
 import { classNames } from "../../../helpers/functions"
+import { request } from "../../../helpers/request"
 import { getSubdomain } from "../../../helpers/user"
 
 export const isUrlValid = (str: string): boolean => {
@@ -39,7 +38,7 @@ export default function AddWebpage({onCancel, setIsAddDocumentationOpen, setIsAd
     }
 
     setIsLoading(true);
-    axios.get(`${API_ENDPOINT}/routes/docs/preview`, {
+    request('GET', 'routes/docs/preview', {
       params: {
         url
       }
@@ -57,18 +56,16 @@ export default function AddWebpage({onCancel, setIsAddDocumentationOpen, setIsAd
 
   const onSubmit = async () => {
     setIsAddDocLoading(true);
-    await axios
-      .post(
-        `${API_ENDPOINT}/routes/docs`,
-        {
-          url,
+    await request('POST', 'routes/docs',
+      {
+        data: {
+          url
         },
-        {
-          params: {
-            userId: user.userId,
-            subdomain: getSubdomain(window.location.host),
-          },
-        }
+        params: {
+          userId: user.userId,
+          subdomain: getSubdomain(window.location.host),
+        },
+      }
     )
 
     setIsAddDocLoading(false);

--- a/web/context/ProfileContext.tsx
+++ b/web/context/ProfileContext.tsx
@@ -78,6 +78,7 @@ export function ProfileContextProvider({ children }: { children: any }) {
     getProfile()
       .then((profile) => {
         setProfile(profile);
+      }).finally(() => {
         setIsLoadingProfile(false);
       });
     getSession()

--- a/web/helpers/api.ts
+++ b/web/helpers/api.ts
@@ -1,2 +1,2 @@
 export const ISDEV = process.env.NODE_ENV === 'development';
-export const API_ENDPOINT = ISDEV ? 'http://localhost:5000' : 'https://connect.mintlify.com'
+export const API_ENDPOINT = ISDEV ? 'http://localhost:5000' : 'https://connect.mintlify.com';

--- a/web/helpers/request.ts
+++ b/web/helpers/request.ts
@@ -1,0 +1,11 @@
+import axios, { AxiosRequestConfig } from "axios";
+
+type Method = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+export const request = (method: Method, endpoint: string, config?: AxiosRequestConfig) => {
+  return axios({
+    method,
+    url: `/api/request/${endpoint}`,
+    ...config
+  })
+}

--- a/web/pages/api/request/[...endpoint].ts
+++ b/web/pages/api/request/[...endpoint].ts
@@ -1,0 +1,30 @@
+import axios from "axios";
+import { NextApiResponse } from "next";
+import { API_ENDPOINT } from "../../../helpers/api";
+import { getSubdomain } from "../../../helpers/user";
+import { withSession } from "../../../lib/withSession";
+
+async function handler(req: any, res: NextApiResponse) {
+  const session = req.session.get('user');
+
+  if (session?.userId == null) {
+    return res.status(400).send({ error: 'User not authenticated' });
+  }
+
+  const { endpoint } = req.query;
+
+  const { data: response } = await axios({
+    method: req.method,
+    url: `${API_ENDPOINT}/${endpoint.join('/')}`,
+    data: req.body,
+    params: {
+      userId: session.userId,
+      subdomain: getSubdomain(req.headers.host),
+      ...req.query,
+    }
+  });
+
+  res.send(response);
+}
+
+export default withSession(handler);

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -1,9 +1,7 @@
-import axios from 'axios'
 import Sidebar from '../components/Sidebar'
 import Layout from '../components/layout'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
-import { API_ENDPOINT } from '../helpers/api'
 import Head from 'next/head'
 import 'react-loading-skeleton/dist/skeleton.css'
 import LoadingItem from '../components/LoadingItem'
@@ -12,10 +10,10 @@ import Setup from '../components/screens/Setup'
 import { DocumentTextIcon } from '@heroicons/react/outline'
 import { Event } from '../components/Event'
 import ActivityBar from '../components/ActivityBar'
-import { getSubdomain } from '../helpers/user'
 import Onboarding from '../components/screens/Onboarding'
 import DocItem from '../components/DocItem'
 import { useProfile } from '../context/ProfileContext'
+import { request } from '../helpers/request'
 
 type Code = {
   _id: string
@@ -53,15 +51,7 @@ export default function Home() {
       return
     }
 
-    const userId = user.userId
-
-    axios
-      .get(`${API_ENDPOINT}/routes/docs`, {
-        params: {
-          userId: userId,
-          subdomain: getSubdomain(window.location.host),
-        },
-      })
+    request('GET', 'routes/docs')
       .then((docsResponse) => {
         const { docs } = docsResponse.data
         setDocs(docs)
@@ -69,34 +59,19 @@ export default function Home() {
       .finally(() => {
         setIsLoading(false)
       })
-
-    axios
-      .get(`${API_ENDPOINT}/routes/events`, {
-        params: {
-          userId,
-          subdomain: getSubdomain(window.location.host),
-          doc: selectedDoc ? selectedDoc._id : undefined,
-        },
-      })
-      .then((eventsResponse) => {
+    request('GET', 'routes/events', {
+      params: {
+        doc: selectedDoc ? selectedDoc._id : undefined,
+      }
+    }).then((eventsResponse) => {
         const { events } = eventsResponse.data
         setEvents(events)
       });
-
-    if (user == null || org == null) {
-      return;
-    }
-
-    axios.get(`${API_ENDPOINT}/routes/org/${org._id}/integrations`, {
-      params: {
-        userId: user.userId,
-        subdomain: getSubdomain(window.location.host)
-      }
-    })
-    .then(({ data }) => {
-      const { integrations } = data;
-      setIntegrationsStatus(integrations);
-    })
+    request('GET', `routes/org/${org._id}/integrations`)
+      .then(({ data }) => {
+        const { integrations } = data;
+        setIntegrationsStatus(integrations);
+      })
 
   }, [org, user, selectedDoc, isAddDocLoading])
 

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -73,7 +73,7 @@ export default function Home() {
         setIntegrationsStatus(integrations);
       })
 
-  }, [org, user, selectedDoc, isAddDocLoading])
+  }, [org, user, selectedDoc, isAddDocLoading]);
 
   if (isLoadingProfile) {
     return null;

--- a/web/pages/settings/account.tsx
+++ b/web/pages/settings/account.tsx
@@ -3,13 +3,11 @@ import toast, { Toaster } from 'react-hot-toast';
 import { UserCircleIcon, UserGroupIcon, ViewGridAddIcon } from "@heroicons/react/outline"
 import { useState, useEffect } from "react"
 import Link from "next/link"
-import axios from "axios"
-import { API_ENDPOINT } from "../../helpers/api"
 import { useRouter } from "next/router"
 import Head from "next/head"
-import { getSubdomain } from "../../helpers/user"
 import { CheckCircleIcon, XIcon } from "@heroicons/react/solid";
 import { useProfile } from "../../context/ProfileContext";
+import { request } from "../../helpers/request";
 
 export type EmailNotifications = {
   monthlyDigest: boolean
@@ -94,8 +92,10 @@ export default function Settings() {
     if (!firstName || firstName === user.firstName) {
       return;
     }
-    await axios.put(`${API_ENDPOINT}/routes/user/${user.userId}/firstname`, {
-      firstName,
+    await request('PUT', `routes/user/${user.userId}/firstname`, {
+      data: {
+        firstName,
+      }
     })
     notify('Profile name updated', 'Your first name has been updated.');
   }
@@ -104,8 +104,10 @@ export default function Settings() {
     if (!lastName || lastName === user.lastName) {
       return;
     }
-    await axios.put(`${API_ENDPOINT}/routes/user/${user.userId}/lastname`, {
-      lastName,
+    await request('PUT', `routes/user/${user.userId}/lastname`, {
+      data: {
+        lastName,
+      }
     })
     notify('Profile name updated', 'Your last name has been updated.');
   }
@@ -113,12 +115,9 @@ export default function Settings() {
   const updateEmailNotifications = async (newNotifications: EmailNotifications) => {
     setNotifications(newNotifications)
     // update the organization's new notifications in the database
-    await axios.put(`${API_ENDPOINT}/routes/org/${org._id}/notifications`, {
-      ...newNotifications,
-    }, {
-      params: {
-        userId: user.userId,
-        subdomain: getSubdomain(window.location.host)
+    await request('PUT', `routes/org/${org._id}/notifications`, {
+      data: {
+        ...newNotifications,
       }
     })
     notify('Updated notification settings', 'Your notification preferences have been updated.');


### PR DESCRIPTION
Not all `axios` requests were replaced, they will be done incrementally.

## How to use request in the future
```
request('GET', 'routes/endpoint', {
 data: BODY,
 params: PARAMS,
})
```

No longer need to pass in `userId` and `subdomain`